### PR TITLE
Change compute unit to "core-hours" instead of "node-hours"

### DIFF
--- a/bin/jobemissions
+++ b/bin/jobemissions
@@ -101,7 +101,7 @@ if not node_info:
 node_cpu_cores = node_info["cpu_cores"]
 node_embodied = node_info["embodied"]
 scope3_per_coreh = node_embodied / node_cpu_cores / (24 * 365 * NODE_LIFETIME)
-scope3_per_coreh = scope3_per_coreh / 1000 # convert to gCO2e
+scope3_per_coreh = scope3_per_coreh * 1000 # convert to gCO2e
 
 #can move somewhere
 


### PR DESCRIPTION
Closes #5.

- calculate `scope3_per_coreh` based on total Scope 3 for the node
- calculate `job_coreh` by multiplying `ElapsedRaw` and `AllocCPUs` values for the job
- calculate `MEAN_CORE_POWER_DRAW` based on ARCHER2 data and use this in calculations
- update output text to refer to core hours