### PR TITLE
Add script to fetch carbon intensity data and save to a file

### DIFF
--- a/scripts/fetch_ci_data.py
+++ b/scripts/fetch_ci_data.py
@@ -6,7 +6,6 @@ import sys
 import urllib.error
 import urllib.request
 from datetime import datetime, timedelta
-from pathlib import Path
 
 
 def get_ci_for_interval(start_time, delta, postcode) -> tuple[str, float]:
@@ -81,7 +80,7 @@ s_day = date_start.day
 
 ci_dir = f"{ci_data_dir}/{s_year}/{s_month:02d}/"
 ci_csv = os.path.join(ci_dir, f"{s_year}{s_month:02d}{s_day:02d}_ci.csv")
-Path(ci_dir).mkdir(parents=True, exist_ok=True)
+os.makedirs(ci_dir, exist_ok=True)
 
 with open(ci_csv, "w") as csv_file:
     writer = csv.writer(csv_file)


### PR DESCRIPTION
- adds script that fetches carbon intensity data from carbonintensity.org.uk
- the script takes a date and an output directory
- it retrieves CI data for half hour intervals across the given date
- the output data is stored in a .csv file in a subfolder of the output directory. Subfolders are organised by year and month.

The eventual aim is to run this script daily, e.g. using a cron job, to automatically fetch carbon intensity data for the previous day and store it in a centralised location on the cluster. This will mean that users can query this data store rather than having to make API calls.