### PR TITLE
Handle missing data in API responses

### DIFF
--- a/bin/jobemissions
+++ b/bin/jobemissions
@@ -171,6 +171,7 @@ else:
             try:
                ci_value = float(tokens[1])
             except TypeError:
+               print(f"No carbon intensity data available for {rounded_time}, using 2024 average value")
                ci_value = 125 # average value for 2024, from NESO
    except Exception as err:
        print(str(err))

--- a/bin/jobemissions
+++ b/bin/jobemissions
@@ -8,6 +8,7 @@ EPCC, 2024
 
 import argparse
 import json
+import math
 import sys
 import urllib.error
 import urllib.request
@@ -168,9 +169,8 @@ else:
       for line in csv_file:
          if job_start_log in line:
             tokens = line.split(",")
-            try:
-               ci_value = float(tokens[1])
-            except TypeError:
+            ci_value = float(tokens[1])
+            if math.isnan(ci_value):
                print(f"No carbon intensity data available for {rounded_time}, using 2024 average value")
                ci_value = 125 # average value for 2024, from NESO
    except Exception as err:

--- a/bin/jobemissions
+++ b/bin/jobemissions
@@ -166,14 +166,17 @@ else:
       #   search for it
       job_start_log = rounded_time.strftime(DATEFORMAT_OUT)
       for line in csv_file:
-          if job_start_log in line:
-              tokens = line.split(",")
-              ci_value = float(tokens[1])
+         if job_start_log in line:
+            tokens = line.split(",")
+            try:
+               ci_value = float(tokens[1])
+            except TypeError:
+               ci_value = 125 # average value for 2024, from NESO
    except Exception as err:
        print(str(err))
        sys.exit(1)
-       
-# Emissions calculations 
+
+# Emissions calculations
 
 # Scope 2
 scope2_emissions = (estimated_kwh * ci_value) / 1000.0

--- a/scripts/fetch_ci_data.py
+++ b/scripts/fetch_ci_data.py
@@ -6,9 +6,10 @@ import sys
 import urllib.error
 import urllib.request
 from datetime import datetime, timedelta
+from typing import Optional
 
 
-def get_ci_for_interval(start_time, delta, postcode) -> tuple[str, float]:
+def get_ci_for_interval(start_time, delta, postcode) -> tuple[str, Optional[float]]:
     """
     Retrieves carbon intensity forecast data for a specified time interval and postcode.
 
@@ -29,7 +30,7 @@ def get_ci_for_interval(start_time, delta, postcode) -> tuple[str, float]:
     end_time_url = end_time.strftime(dateformat)
 
     # Query carbonintensity to get the JSON information
-    ci_url = f"https://api.carbonintensity.org.uk/regional/intensity/{start_time_url}/{end_time_url}/postcode/{postcode}"
+    ci_url: str = f"https://api.carbonintensity.org.uk/regional/intensity/{start_time_url}/{end_time_url}/postcode/{postcode}"
     ci_response = None
     try:
         ci_response = urllib.request.urlopen(ci_url)
@@ -40,7 +41,11 @@ def get_ci_for_interval(start_time, delta, postcode) -> tuple[str, float]:
     # Parse the JSON retrieved from the website
     ci_json = ci_response.read()
     ci_d = json.loads(ci_json)
-    ci_value = ci_d["data"]["data"][0]["intensity"]["forecast"]
+    try:
+        ci_value = ci_d["data"]["data"][0]["intensity"]["forecast"]
+    except IndexError:
+        print(f"No data available for {start_time}!")
+        ci_value = None
 
     return start_time_url, ci_value
 

--- a/scripts/fetch_ci_data.py
+++ b/scripts/fetch_ci_data.py
@@ -1,15 +1,15 @@
 import argparse
 import csv
 import json
+import math
 import os
 import sys
 import urllib.error
 import urllib.request
 from datetime import datetime, timedelta
-from typing import Optional
 
 
-def get_ci_for_interval(start_time, delta, postcode) -> tuple[str, Optional[float]]:
+def get_ci_for_interval(start_time, delta, postcode) -> tuple[str, float]:
     """
     Retrieves carbon intensity forecast data for a specified time interval and postcode.
 
@@ -45,7 +45,7 @@ def get_ci_for_interval(start_time, delta, postcode) -> tuple[str, Optional[floa
         ci_value = ci_d["data"]["data"][0]["intensity"]["forecast"]
     except IndexError:
         print(f"No data available for {start_time}!")
-        ci_value = None
+        ci_value = math.nan
 
     return start_time_url, ci_value
 


### PR DESCRIPTION
The Carbon Intensity API sometimes returns no data (but without an HTTPError) for a time period. For example, the time period 2025-08-10 23:30 until 2025-08-11 03:00. 

This PR adds handling of this case, by storing `nan` in the cached data file. In the `jobemissions` script this is then handled by replacing any `nan` value with the 2024 average CI value (from [this NESO report](https://www.neso.energy/news/britains-electricity-explained-2024-review)).